### PR TITLE
Allow environment groups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Incompass\\InjectionBundle": "tests"
+            "Tests\\Incompass\\InjectionBundle\\": "tests"
         }
     }
 }

--- a/src/Annotation/Inject.php
+++ b/src/Annotation/Inject.php
@@ -16,6 +16,10 @@ class Inject
     public $tags = [];
     public $arguments = [];
     public $environments = [];
+    /**
+     * @Enum({"exclude", "include"})
+     * @var string
+     */
     public $environmentStrategy = 'exclude';
     public $aliases = [];
     public $autowired = true;

--- a/src/Annotation/Inject.php
+++ b/src/Annotation/Inject.php
@@ -16,6 +16,7 @@ class Inject
     public $tags = [];
     public $arguments = [];
     public $environments = [];
+    public $environmentGroups = [];
     /**
      * @Enum({"exclude", "include"})
      * @var string

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('environment_groups')
                     ->useAttributeAsKey('group')
+                    ->defaultValue([])
                     ->arrayPrototype()
                     ->children()
                         ->arrayNode('environments')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,6 +29,16 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')
                     ->end()
                 ->end()
+                ->arrayNode('environment_groups')
+                    ->useAttributeAsKey('group')
+                    ->arrayPrototype()
+                    ->children()
+                        ->arrayNode('environments')
+                            ->scalarPrototype()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end();
         return $treeBuilder;
     }

--- a/src/DependencyInjection/InjectionExtension.php
+++ b/src/DependencyInjection/InjectionExtension.php
@@ -3,7 +3,6 @@
 namespace Incompass\InjectionBundle\DependencyInjection;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Incompass\InjectionBundle\Annotation\Inject;
 use Incompass\InjectionBundle\InjectProcessor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;

--- a/src/DependencyInjection/InjectionExtension.php
+++ b/src/DependencyInjection/InjectionExtension.php
@@ -3,6 +3,7 @@
 namespace Incompass\InjectionBundle\DependencyInjection;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Incompass\InjectionBundle\Annotation\Inject;
 use Incompass\InjectionBundle\InjectProcessor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -26,6 +27,7 @@ class InjectionExtension extends Extension
         $finder = $this->getFinder();
         $reader = $this->getReader();
         $projectDir = $container->getParameter('kernel.project_dir');
+        $container->setParameter('injection.environment_groups', $config['environment_groups']);
         foreach ($config['paths'] as $path => $prefix) {
             foreach ($finder->in($projectDir.'/'.$path)->name('*.php') as $file => $info) {
                 $pathLen = \strlen($projectDir.'/'.$path);

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -27,8 +27,14 @@ class InjectProcessor
             return;
         }
 
-        if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
-            return;
+        if ($annotation->environmentStrategy === 'exclude') {
+            if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
+                return;
+            }
+        } else {
+            if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
+                return;
+            }
         }
 
         if ($annotation->parent) {

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -27,13 +27,33 @@ class InjectProcessor
             return;
         }
 
+        $environmentGroups = $container->getParameter('injection.environment_groups');
+
         if ($annotation->environmentStrategy === 'exclude') {
             if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
                 return;
             }
+            foreach ($annotation->environmentGroups as $group) {
+                if (\in_array(
+                    $container->getParameter('kernel.environment'),
+                    $environmentGroups[$group]['environments'],
+                    true)
+                ) {
+                    return;
+                }
+            }
         } else {
             if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
                 return;
+            }
+            foreach ($annotation->environmentGroups as $group) {
+                if (!\in_array(
+                    $container->getParameter('kernel.environment'),
+                    $environmentGroups[$group]['environments'],
+                    true)
+                ) {
+                    return;
+                }
             }
         }
 

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -34,7 +34,8 @@ class InjectProcessor
                 return;
             }
             foreach ($annotation->environmentGroups as $group) {
-                if (\in_array(
+                if (isset($environmentGroups[$group]['environments']) &&
+                    \in_array(
                     $container->getParameter('kernel.environment'),
                     $environmentGroups[$group]['environments'],
                     true)
@@ -47,7 +48,8 @@ class InjectProcessor
                 return;
             }
             foreach ($annotation->environmentGroups as $group) {
-                if (!\in_array(
+                if (isset($environmentGroups[$group]['environments']) &&
+                    !\in_array(
                     $container->getParameter('kernel.environment'),
                     $environmentGroups[$group]['environments'],
                     true)

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -30,6 +30,11 @@ class InjectProcessor
         $environmentGroups = $container->getParameter('injection.environment_groups');
 
         if ($annotation->environmentStrategy === 'exclude') {
+            if ($annotation->environments) {
+                if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
+                    return;
+                }
+            }
             if ($environmentGroups) {
                 foreach ($annotation->environmentGroups as $group) {
                     if (isset($environmentGroups[$group]['environments']) &&
@@ -41,12 +46,13 @@ class InjectProcessor
                         return;
                     }
                 }
-            } else {
-                if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
+            }
+        } else {
+            if ($annotation->environments) {
+                if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
                     return;
                 }
             }
-        } else {
             if ($environmentGroups) {
                 foreach ($annotation->environmentGroups as $group) {
                     if (isset($environmentGroups[$group]['environments']) &&
@@ -57,10 +63,6 @@ class InjectProcessor
                     ) {
                         return;
                     }
-                }
-            } else {
-                if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
-                    return;
                 }
             }
         }

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -29,41 +29,23 @@ class InjectProcessor
 
         $environmentGroups = $container->getParameter('injection.environment_groups');
 
-        if ($annotation->environmentStrategy === 'exclude') {
-            if ($annotation->environments) {
-                if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
-                    return;
-                }
-            }
-            if ($environmentGroups) {
-                foreach ($annotation->environmentGroups as $group) {
-                    if (isset($environmentGroups[$group]['environments']) &&
-                        \in_array(
-                            $container->getParameter('kernel.environment'),
-                            $environmentGroups[$group]['environments'],
-                            true)
-                    ) {
-                        return;
+        foreach ($annotation->environmentGroups as $group) {
+            if (isset($environmentGroups[$group]['environments'])) {
+                foreach ($environmentGroups[$group]['environments'] as $environment) {
+                    if (!\in_array($environment, $annotation->environments, true)) {
+                        $annotation->environments[] = $environment;
                     }
                 }
+            }
+        }
+
+        if ($annotation->environmentStrategy === 'exclude') {
+            if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
+                return;
             }
         } else {
-            if ($annotation->environments) {
-                if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
-                    return;
-                }
-            }
-            if ($environmentGroups) {
-                foreach ($annotation->environmentGroups as $group) {
-                    if (isset($environmentGroups[$group]['environments']) &&
-                        !\in_array(
-                            $container->getParameter('kernel.environment'),
-                            $environmentGroups[$group]['environments'],
-                            true)
-                    ) {
-                        return;
-                    }
-                }
+            if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
+                return;
             }
         }
 

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -30,30 +30,36 @@ class InjectProcessor
         $environmentGroups = $container->getParameter('injection.environment_groups');
 
         if ($annotation->environmentStrategy === 'exclude') {
-            if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
-                return;
-            }
-            foreach ($annotation->environmentGroups as $group) {
-                if (isset($environmentGroups[$group]['environments']) &&
-                    \in_array(
-                    $container->getParameter('kernel.environment'),
-                    $environmentGroups[$group]['environments'],
-                    true)
-                ) {
+            if ($environmentGroups) {
+                foreach ($annotation->environmentGroups as $group) {
+                    if (isset($environmentGroups[$group]['environments']) &&
+                        \in_array(
+                            $container->getParameter('kernel.environment'),
+                            $environmentGroups[$group]['environments'],
+                            true)
+                    ) {
+                        return;
+                    }
+                }
+            } else {
+                if (\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
                     return;
                 }
             }
         } else {
-            if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
-                return;
-            }
-            foreach ($annotation->environmentGroups as $group) {
-                if (isset($environmentGroups[$group]['environments']) &&
-                    !\in_array(
-                    $container->getParameter('kernel.environment'),
-                    $environmentGroups[$group]['environments'],
-                    true)
-                ) {
+            if ($environmentGroups) {
+                foreach ($annotation->environmentGroups as $group) {
+                    if (isset($environmentGroups[$group]['environments']) &&
+                        !\in_array(
+                            $container->getParameter('kernel.environment'),
+                            $environmentGroups[$group]['environments'],
+                            true)
+                    ) {
+                        return;
+                    }
+                }
+            } else {
+                if (!\in_array($container->getParameter('kernel.environment'), $annotation->environments, true)) {
                     return;
                 }
             }

--- a/tests/InjectProcessorTest.php
+++ b/tests/InjectProcessorTest.php
@@ -122,6 +122,75 @@ class InjectProcessorTest extends TestCase
         $this->processor->process($annotation, 'class', $this->container->reveal());
     }
 
+    /** @test */
+    public function it_does_not_configure_if_environment_excluded(): void
+    {
+        $annotation = new Inject();
+        $annotation->parent = 'parent';
+        $annotation->environments = ['test'];
+
+        $this->container->setDefinition('class', Argument::type(ChildDefinition::class))->shouldNotBeCalled();
+
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
+        $this->processor->process($annotation, 'class', $this->container->reveal());
+    }
+
+    /** @test */
+    public function it_does_configure_if_environment_included(): void
+    {
+        $annotation = new Inject();
+        $annotation->parent = 'parent';
+        $annotation->environments = ['test'];
+        $annotation->environmentStrategy = 'include';
+
+        $this->container->setDefinition('class', Argument::type(ChildDefinition::class))->shouldBeCalled();
+
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
+        $this->processor->process($annotation, 'class', $this->container->reveal());
+    }
+
+    /** @test */
+    public function it_does_not_configure_if_environment_group_excluded(): void
+    {
+        $annotation = new Inject();
+        $annotation->parent = 'parent';
+        $annotation->environmentGroups = ['test'];
+        $annotation->environmentStrategy = 'exclude';
+
+        $this->container->setDefinition('class', Argument::type(ChildDefinition::class))->shouldNotBeCalled();
+
+        $this->container->getParameter('injection.environment_groups')->willReturn(
+            [
+                'test' =>
+                    [
+                        'environments' => ['test']
+                    ]
+            ]
+        );
+        $this->processor->process($annotation, 'class', $this->container->reveal());
+    }
+
+    /** @test */
+    public function it_configures_if_environment_group_included(): void
+    {
+        $annotation = new Inject();
+        $annotation->parent = 'parent';
+        $annotation->environmentGroups = ['test'];
+        $annotation->environmentStrategy = 'include';
+
+        $this->container->setDefinition('class', Argument::type(ChildDefinition::class))->shouldBeCalled();
+
+        $this->container->getParameter('injection.environment_groups')->willReturn(
+            [
+                'test' =>
+                    [
+                        'environments' => ['test']
+                    ]
+            ]
+        );
+        $this->processor->process($annotation, 'class', $this->container->reveal());
+    }
+
     public function it_sets_tags(): void
     {
         $annotation = new Inject();

--- a/tests/InjectProcessorTest.php
+++ b/tests/InjectProcessorTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Incompass\InjectionBundle;
 
-use InjectionBundle\Annotation\Inject;
-use InjectionBundle\Annotation\MethodCall;
-use InjectionBundle\InjectProcessor;
+use Incompass\InjectionBundle\Annotation\Inject;
+use Incompass\InjectionBundle\Annotation\MethodCall;
+use Incompass\InjectionBundle\InjectProcessor;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\DependencyInjection\Alias;
@@ -34,6 +34,7 @@ class InjectProcessorTest extends TestCase
     {
         $this->container->setDefinition(Argument::any(), Argument::any())->shouldNotBeCalled();
 
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
         $this->processor->process(new \stdClass(), \stdClass::class, $this->container->reveal());
     }
 
@@ -45,6 +46,7 @@ class InjectProcessorTest extends TestCase
 
         $this->container->setDefinition('class', Argument::type(ChildDefinition::class))->shouldBeCalled();
 
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
         $this->processor->process($annotation, 'class', $this->container->reveal());
     }
 
@@ -55,6 +57,7 @@ class InjectProcessorTest extends TestCase
 
         $this->container->setDefinition('class', Argument::type(Definition::class))->shouldBeCalled();
 
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
         $this->processor->process($annotation, 'class', $this->container->reveal());
     }
 
@@ -68,6 +71,7 @@ class InjectProcessorTest extends TestCase
         $this->container->setAlias('alias2', Argument::type(Alias::class))->shouldBeCalled();
         $this->container->setDefinition('class', Argument::type(Definition::class))->shouldBeCalled();
 
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
         $this->processor->process($annotation, 'class', $this->container->reveal());
     }
 
@@ -75,10 +79,10 @@ class InjectProcessorTest extends TestCase
     public function it_sets_arguments(): void
     {
         $annotation = new Inject();
-        $argument1 = new \InjectionBundle\Annotation\Argument();
+        $argument1 = new \Incompass\InjectionBundle\Annotation\Argument();
         $argument1->name = 'arg1';
         $argument1->value = 'val1';
-        $argument2 = new \InjectionBundle\Annotation\Argument();
+        $argument2 = new \Incompass\InjectionBundle\Annotation\Argument();
         $argument2->name = 'arg2';
         $argument2->value = 'val2';
 
@@ -87,6 +91,8 @@ class InjectProcessorTest extends TestCase
         $this->container->setDefinition('class', Argument::that(function (Definition $definition) {
             return empty(array_diff(['$arg1' => 'val1', '$arg2' => 'val2'], $definition->getArguments()));
         }))->shouldBeCalled();
+
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
         $this->processor->process($annotation, 'class', $this->container->reveal());
     }
 
@@ -111,6 +117,8 @@ class InjectProcessorTest extends TestCase
                 && $calls[1][1][0] === 'arg1'
                 && $calls[1][1][1] === 'arg2';
         }))->shouldBeCalled();
+
+        $this->container->getParameter('injection.environment_groups')->willReturn([]);
         $this->processor->process($annotation, 'class', $this->container->reveal());
     }
 

--- a/tests/InjectProcessorTest.php
+++ b/tests/InjectProcessorTest.php
@@ -154,6 +154,7 @@ class InjectProcessorTest extends TestCase
     {
         $annotation = new Inject();
         $annotation->parent = 'parent';
+        $annotation->environments = ['staging'];
         $annotation->environmentGroups = ['test'];
         $annotation->environmentStrategy = 'exclude';
 


### PR DESCRIPTION
This allows group environments to be used instead of individual environments for including/excluding services. See tests for examples. 

An example of configuration in a main project would be:

```
$container->loadFromExtension('injection', [
    'environment_groups' => [
        [
            'group' => 'QA',
            'environments' => [
                'test',
                'staging'
            ]
        ]
    ]
]);
```

and the corresponding `Inject` annotation would then look like:

```
@Inject(id="my_service", environmentStrategy="include", environmentGroups={"QA"})
```