### PR TITLE
Allow setting factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+php:
+- '7.2'
+cache:
+  directories:
+  - "$HOME/.composer/cache/files"
+before_install:
+- composer global require hirak/prestissimo
+before_script:
+- composer install
+script:
+- vendor/bin/phpunit tests/InjectProccessorTest.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
 before_script:
 - composer install
 script:
-- vendor/bin/phpunit tests/InjectProccessorTest.php
+- vendor/bin/phpunit ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 php:
 - '7.2'
+branches:
+  only:
+  - master
 cache:
   directories:
   - "$HOME/.composer/cache/files"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+[![Build Status](https://travis-ci.org/incompass/InjectionBundle.svg?branch=master)](https://travis-ci.org/incompass/InjectionBundle)
+[![Latest Stable Version](https://poser.pugx.org/incompass/injection-bundle/v/stable.svg)](https://packagist.org/packages/incompass/injection-bundle)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/incompass/injection-bundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/incompass/injection-bundle/?branch=master)
+[![Code Coverage](https://scrutinizer-ci.com/g/incompass/injection-bundle/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/incompass/injection-bundle/?branch=master)
+
+Prerequisites
+-------------
+
+This bundle requires symfony 3.4+ or 4.0+
+
+Installation
+------------
+
+### Install with composer
+
+```bash
+composer require incompass/injection-bundle
+```
+
+### Enable the bundle
+
+In bundles.php add
+
+```php
+return [
+    // ...
+    Incompass\InjectionBundle\InjectionBundle::class => ['all' => true]
+    // ...
+];
+```
+
+Usage
+-----
+
+To configure environment groups, add something like to the following do your bundle configuration:
+
+```php
+$c->loadFromExtension('injection', [
+    'environment_groups' => [
+        [
+            'group' => 'all',
+            'environments' => ['dev', 'staging', 'prod']
+        ],
+        [
+            'group' => 'prod-like',
+            'environments' => ['staging', 'prod']
+        ],
+    ]
+]);
+
+```
+
+To inject a simple service that does not require any special configuration do the following:
+
+```php
+/**
+  * @Inject()
+  */
+class SomeService {
+    // ...
+}
+```
+
+By default, the bundle will use the class name as the service id. If you would like to change the id, use the id parameter in the `@Inject` annotation:
+
+```php
+/**
+  * @Inject(id="some_service")
+  */
+class SomeService {
+    // ...
+}
+```
+
+More documentation coming soon

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,11 @@
 {
     "name": "incompass/injection-bundle",
+    "description": "Inject with Annotations for Symfony",
     "type": "symfony-bundle",
     "keywords": ["Symfony"],
     "license": "MIT",
     "require": {
+        "php": ">= 7.0",
         "doctrine/annotations": "^1.6",
         "symfony/dependency-injection": "^3.4 | ^4.0",
         "symfony/http-kernel": "^3.4 | ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["Symfony"],
     "license": "MIT",
     "require": {
-        "php": ">= 7.0",
+        "php": ">= 7.1",
         "doctrine/annotations": "^1.6",
         "symfony/dependency-injection": "^3.4 | ^4.0",
         "symfony/http-kernel": "^3.4 | ^4.0",

--- a/src/Annotation/Argument.php
+++ b/src/Annotation/Argument.php
@@ -12,6 +12,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *
  * @Annotation
  * @Target("ANNOTATION")
+ *
+ * @codeCoverageIgnore
  */
 class Argument
 {

--- a/src/Annotation/Factory.php
+++ b/src/Annotation/Factory.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Annotation
  * @Target("ANNOTATION")
  *
- * @codeCoverageIgnore 
+ * @codeCoverageIgnore
  */
 class Factory
 {

--- a/src/Annotation/Factory.php
+++ b/src/Annotation/Factory.php
@@ -12,6 +12,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *
  * @Annotation
  * @Target("ANNOTATION")
+ *
+ * @codeCoverageIgnore 
  */
 class Factory
 {

--- a/src/Annotation/Factory.php
+++ b/src/Annotation/Factory.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Incompass\InjectionBundle\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * Class Factory
+ *
+ * @author James Matsumura <james@casechek.com>
+ *
+ * @Annotation
+ * @Target("ANNOTATION")
+ */
+class Factory
+{
+    /** @Required() */
+    public $class;
+
+    /** @Required() */
+    public $method;
+}

--- a/src/Annotation/Inject.php
+++ b/src/Annotation/Inject.php
@@ -9,6 +9,8 @@ namespace Incompass\InjectionBundle\Annotation;
  *
  * @Annotation
  * @Target("CLASS")
+ *
+ * @codeCoverageIgnore
  */
 class Inject
 {

--- a/src/Annotation/Inject.php
+++ b/src/Annotation/Inject.php
@@ -14,12 +14,12 @@ class Inject
 {
     public $id;
     public $parent;
+    public $factory;
 
     public $aliases = [];
     public $arguments = [];
     public $environments = [];
     public $environmentGroups = [];
-    public $factories = [];
     public $methodCalls = [];
     public $tags = [];
 

--- a/src/Annotation/Inject.php
+++ b/src/Annotation/Inject.php
@@ -13,22 +13,26 @@ namespace Incompass\InjectionBundle\Annotation;
 class Inject
 {
     public $id;
-    public $tags = [];
+    public $parent;
+
+    public $aliases = [];
     public $arguments = [];
     public $environments = [];
     public $environmentGroups = [];
+    public $factories = [];
+    public $methodCalls = [];
+    public $tags = [];
+
     /**
      * @Enum({"exclude", "include"})
      * @var string
      */
     public $environmentStrategy = 'exclude';
-    public $aliases = [];
-    public $autowired = true;
-    public $autoconfigured = true;
-    public $public = false;
-    public $lazy = false;
+
     public $abstract = false;
-    public $parent;
+    public $autoconfigured = true;
+    public $autowired = true;
+    public $lazy = false;
+    public $public = false;
     public $shared = true;
-    public $methodCalls = [];
 }

--- a/src/Annotation/MethodCall.php
+++ b/src/Annotation/MethodCall.php
@@ -14,6 +14,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *
  * @Annotation
  * @Target("ANNOTATION")
+ *
+ * @codeCoverageIgnore
  */
 class MethodCall
 {

--- a/src/Annotation/Tag.php
+++ b/src/Annotation/Tag.php
@@ -12,6 +12,8 @@ use Doctrine\Common\Annotations\Annotation\Target;
  *
  * @Annotation
  * @Target("ANNOTATION")
+ *
+ * @codeCoverageIgnore
  */
 class Tag
 {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,6 +9,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * Class Configuration
  *
  * @author  Joe Mizzi <themizzi@me.com>
+ *
+ * @codeCoverageIgnore
  */
 class Configuration implements ConfigurationInterface
 {

--- a/src/DependencyInjection/InjectionExtension.php
+++ b/src/DependencyInjection/InjectionExtension.php
@@ -12,6 +12,8 @@ use Symfony\Component\Finder\Finder;
  * Class InjectionExtension
  *
  * @author  Joe Mizzi <themizzi@me.com>
+ *
+ * @codeCoverageIgnore
  */
 class InjectionExtension extends Extension
 {

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -6,6 +6,7 @@
 namespace Incompass\InjectionBundle;
 
 use Incompass\InjectionBundle\Annotation\Argument;
+use Incompass\InjectionBundle\Annotation\Factory;
 use Incompass\InjectionBundle\Annotation\Inject;
 use Incompass\InjectionBundle\Annotation\MethodCall;
 use Incompass\InjectionBundle\Annotation\Tag;
@@ -72,6 +73,11 @@ class InjectProcessor
         /** @var MethodCall $methodCall */
         foreach ($annotation->methodCalls as $methodCall) {
             $definition->addMethodCall($methodCall->method, $methodCall->arguments);
+        }
+
+        /** @var Factory $factory */
+        foreach ($annotation->factories as $factory) {
+            $definition->setFactory([$factory->class, $factory->method]);
         }
 
         /**

--- a/src/InjectProcessor.php
+++ b/src/InjectProcessor.php
@@ -57,6 +57,10 @@ class InjectProcessor
             $definition = new Definition($class);
         }
 
+        if ($annotation->factory) {
+            $definition->setFactory([$annotation->factory->class, $annotation->factory->method]);
+        }
+
         foreach ($annotation->aliases as $alias) {
             $container->setAlias($alias, new Alias($class));
         }
@@ -73,11 +77,6 @@ class InjectProcessor
         /** @var MethodCall $methodCall */
         foreach ($annotation->methodCalls as $methodCall) {
             $definition->addMethodCall($methodCall->method, $methodCall->arguments);
-        }
-
-        /** @var Factory $factory */
-        foreach ($annotation->factories as $factory) {
-            $definition->setFactory([$factory->class, $factory->method]);
         }
 
         /**

--- a/tests/InjectProcessorTest.php
+++ b/tests/InjectProcessorTest.php
@@ -224,7 +224,7 @@ class InjectProcessorTest extends TestCase
         $factory->class = 'factory';
         $factory->method = 'method';
 
-        $annotation->factories = [$factory];
+        $annotation->factory = $factory;
 
         $this->container->setDefinition('class', Argument::that(function (Definition $definition) {
             return empty(array_diff(['factory', 'method'], $definition->getFactory()));


### PR DESCRIPTION
This allows the `setFactory` method to be called via the bundle. Example if injecting on an interface:

```
 * @Inject(environmentStrategy="include", environmentGroups={"everything"},
 *     factories={
 *          @Factory(class=This\Awesome\Factory::class, method="createTheBestClass")
 *     }
 * )
```